### PR TITLE
bumped onyx dev dependency to 0.9.15, fixed aeron namespace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.onyxplatform/lib-onyx "0.9.10.0"
+(defproject org.onyxplatform/lib-onyx "0.9.15.0"
   :description "A library to support additional functionality in Onyx"
   :url "https://github.com/onyx-platform/lib-onyx"
   :license {:name "Eclipse Public License"
@@ -21,7 +21,7 @@
                  [ring "1.4.0"]
                  [aero "1.0.0-beta2"]]
   :profiles {:dev {:dependencies [^{:voom {:repo "git@github.com:onyx-platform/onyx.git" :branch "master"}}
-                                  [org.onyxplatform/onyx "0.9.7"]
+                                  [org.onyxplatform/onyx "0.9.15"]
                                   [de.ubercode.clostache/clostache "1.4.0"]]
                    :plugins [[codox "0.8.8"]
                              [lein-set-version "0.4.1"]

--- a/src/lib_onyx/media_driver.clj
+++ b/src/lib_onyx/media_driver.clj
@@ -1,8 +1,8 @@
 (ns lib-onyx.media-driver
   (:require [clojure.core.async :refer [chan <!!]]
             [clojure.tools.cli :refer [parse-opts]])
-  (:import [uk.co.real_logic.aeron Aeron$Context]
-           [uk.co.real_logic.aeron.driver MediaDriver MediaDriver$Context ThreadingMode])
+  (:import [io.aeron Aeron$Context]
+           [io.aeron.driver MediaDriver MediaDriver$Context ThreadingMode])
   (:gen-class))
 
 (defn pick-threading-mode [threading-mode]


### PR DESCRIPTION
Attempted to update the media-driver to work with the new version of aeron introduced in 0.9.15.0.