### PR TITLE
Fixed method name of io.aeron Context  dirsDeleteOnStart -> dirDeleteOnStart

### DIFF
--- a/src/lib_onyx/media_driver.clj
+++ b/src/lib_onyx/media_driver.clj
@@ -36,7 +36,7 @@
                     Use -t to supply an alternative threading mode.")
         ctx (cond-> (MediaDriver$Context.)
               threading-mode (.threadingMode threading-mode-obj)
-              delete-dirs (.dirsDeleteOnStart delete-dirs))
+              delete-dirs (.dirDeleteOnStart delete-dirs))
         media-driver (try (MediaDriver/launch ctx)
                           (catch IllegalStateException ise
                             (throw (Exception.


### PR DESCRIPTION
Method name has been changed in io.aeron 1.4.1 (changelog: https://github.com/real-logic/aeron/wiki/Change-Log#141-25-aug-2017) and cause of Exception below:
```
 onyx-peers_1    | Starting media driver with threading mode: shared .
onyx-peers_1    |                     Use -t to supply an alternative threading mode.
onyx-peers_1    | Exception in thread "main" java.lang.IllegalArgumentException: No matching method found: dirsDeleteOnStart for class io.aeron.driver.MediaDriver$Context
onyx-peers_1    | 	at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:53)
onyx-peers_1    | 	at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:28)
onyx-peers_1    | 	at lib_onyx.media_driver$_main.invokeStatic(media_driver.clj:39)
onyx-peers_1    | 	at lib_onyx.media_driver$_main.doInvoke(media_driver.clj:23)
onyx-peers_1    | 	at clojure.lang.RestFn.applyTo(RestFn.java:137)
onyx-peers_1    | 	at clojure.lang.Var.applyTo(Var.java:702)
onyx-peers_1    | 	at clojure.core$apply.invokeStatic(core.clj:657)
onyx-peers_1    | 	at clojure.main$main_opt.invokeStatic(main.clj:316)
onyx-peers_1    | 	at clojure.main$main_opt.invoke(main.clj:312)
onyx-peers_1    | 	at clojure.main$main.invokeStatic(main.clj:423)
onyx-peers_1    | 	at clojure.main$main.doInvoke(main.clj:386)
onyx-peers_1    | 	at clojure.lang.RestFn.applyTo(RestFn.java:137)
onyx-peers_1    | 	at clojure.lang.Var.applyTo(Var.java:702)
onyx-peers_1    | 	at clojure.main.main(main
```